### PR TITLE
Improve slot UI layout

### DIFF
--- a/web/src/components/inventory/InventoryHotbar.tsx
+++ b/web/src/components/inventory/InventoryHotbar.tsx
@@ -4,9 +4,45 @@ import useNuiEvent from '../../hooks/useNuiEvent';
 import { Items } from '../../store/items';
 import WeightBar from '../utils/WeightBar';
 import { useAppSelector } from '../../store';
+import useFitText from '../../hooks/useFitText';
 import { selectLeftInventory } from '../../store/inventory';
-import { SlotWithItem } from '../../typings';
+import { Slot, SlotWithItem } from '../../typings';
 import SlideUp from '../utils/transitions/SlideUp';
+
+const HotbarItem: React.FC<{ item: Slot }> = ({ item }) => {
+  const labelText = item.metadata?.label ? item.metadata.label : Items[item.name]?.label || item.name;
+  const labelRef = useFitText(labelText);
+
+  return (
+    <>
+      {isSlotWithItem(item) && (
+        <div className="item-slot-wrapper">
+          <div className="item-slot-header-wrapper">
+            {item.weight !== undefined && (
+              <div className="inventory-slot-weight">
+                {(item.weight / 1000).toLocaleString('en-us', {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+                kg
+              </div>
+            )}
+            <div className="inventory-slot-number">{item.slot}</div>
+            <p className="item-slot-amount">{item.count ? item.count.toLocaleString('en-us') + `x` : ''}</p>
+          </div>
+          <div>
+            <div className="inventory-slot-label-box">
+              <div className="inventory-slot-label-text" ref={labelRef}>
+                {labelText}
+              </div>
+              {item?.durability !== undefined && <WeightBar percent={item.durability} durability />}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
 
 const InventoryHotbar: React.FC = () => {
   const [hotbarVisible, setHotbarVisible] = useState(false);
@@ -36,31 +72,7 @@ const InventoryHotbar: React.FC = () => {
             }}
             key={`hotbar-${item.slot}`}
           >
-            {isSlotWithItem(item) && (
-              <div className="item-slot-wrapper">
-                <div className="item-slot-header-wrapper">
-                  {item.weight !== undefined && (
-                    <div className="inventory-slot-weight">
-                      {(item.weight / 1000).toLocaleString('en-us', {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                      kg
-                    </div>
-                  )}
-                  <div className="inventory-slot-number">{item.slot}</div>
-                  <p className="item-slot-amount">{item.count ? item.count.toLocaleString('en-us') + `x` : ''}</p>
-                </div>
-                <div>
-                  <div className="inventory-slot-label-box">
-                    <div className="inventory-slot-label-text">
-                      {item.metadata?.label ? item.metadata.label : Items[item.name]?.label || item.name}
-                    </div>
-                    {item?.durability !== undefined && <WeightBar percent={item.durability} durability />}
-                  </div>
-                </div>
-              </div>
-            )}
+            <HotbarItem item={item} />
           </div>
         ))}
       </div>

--- a/web/src/components/inventory/InventorySlot.tsx
+++ b/web/src/components/inventory/InventorySlot.tsx
@@ -15,6 +15,7 @@ import { ItemsPayload } from '../../reducers/refreshSlots';
 import { closeTooltip, openTooltip } from '../../store/tooltip';
 import { openContextMenu } from '../../store/contextMenu';
 import { useMergeRefs } from '@floating-ui/react';
+import useFitText from '../../hooks/useFitText';
 
 interface SlotProps {
   inventoryId: Inventory['id'];
@@ -30,6 +31,8 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
   const manager = useDragDropManager();
   const dispatch = useAppDispatch();
   const timerRef = useRef<number | null>(null);
+  const labelText = item.metadata?.label ? item.metadata.label : Items[item.name]?.label || item.name;
+  const labelRef = useFitText(labelText);
 
   const canDrag = useCallback(() => {
     return canPurchaseItem(item, { type: inventoryType, groups: inventoryGroups }) && canCraftItem(item, inventoryType);
@@ -203,8 +206,8 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
               </>
             )}
             <div className="inventory-slot-label-box">
-              <div className="inventory-slot-label-text">
-                {item.metadata?.label ? item.metadata.label : Items[item.name]?.label || item.name}
+              <div className="inventory-slot-label-text" ref={labelRef}>
+                {labelText}
               </div>
               {inventoryType !== 'shop' && item?.durability !== undefined && (
                 <WeightBar percent={item.durability} durability />

--- a/web/src/hooks/useFitText.ts
+++ b/web/src/hooks/useFitText.ts
@@ -1,0 +1,27 @@
+import { useLayoutEffect, useRef } from 'react';
+
+const useFitText = (text: string, maxFontSize = 0.7) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const parent = el.parentElement;
+    if (!parent) return;
+
+    el.style.whiteSpace = 'nowrap';
+    let fontSize = maxFontSize;
+    el.style.fontSize = `${fontSize}vw`;
+
+    const parentWidth = parent.clientWidth;
+    while (el.scrollWidth > parentWidth && fontSize > 0.3) {
+      fontSize -= 0.05;
+      el.style.fontSize = `${fontSize}vw`;
+    }
+  }, [text, maxFontSize]);
+
+  return ref;
+};
+
+export default useFitText;

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -395,10 +395,12 @@ button:active {
   text-align: center;
 }
 
+
 .inventory-slot-label-text {
   text-transform: uppercase;
   padding: 0.2vw;
-  word-break: break-word;
+  white-space: nowrap;
+  overflow: hidden;
 
   font-family: $mainFont;
   font-size: 0.7vw;
@@ -411,6 +413,7 @@ button:active {
   font-weight: bold;
   color: $textColor;
   text-align: center;
+  padding: 0 0.2vw;
 }
 
 .inventory-slot-number {
@@ -452,6 +455,7 @@ button:active {
     top: 0.3vw;
     font-size: 0.55vw;
     font-weight: bold;
+    padding: 0 0.2vw;
   }
 }
 


### PR DESCRIPTION
## Summary
- add padding around slot weight and quantity displays
- keep label text on one line by dynamically shrinking font

## Testing
- `npm run build` *(fails: Cannot find module '@reduxjs/toolkit' or its corresponding type declarations)*