### PR TITLE
Center hotbar markers in inventory

### DIFF
--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -344,6 +344,12 @@ button:active {
   padding-top: 0.5vw;
 }
 
+// center hotbar numbers inside inventory hotbar slots
+.hotinventory-grid-container .inventory-slot-number {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
 .label-container {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Summary
- fix styling to center hotbar slot numbers when viewing hotbar inside the inventory

## Testing
- `pnpm run format`
- `pnpm run build` *(fails: modules missing)*