### PR TITLE
Highlight contraband items in hotbar

### DIFF
--- a/web/src/components/inventory/InventoryHotbar.tsx
+++ b/web/src/components/inventory/InventoryHotbar.tsx
@@ -69,7 +69,11 @@ const InventoryHotbar: React.FC = () => {
           <div
             className="hotbar-item-slot"
             style={{
-              backgroundColor: isSlotWithItem(item) ? 'rgba(142, 142, 142,0.63)' : 'rgba(71, 71, 71, 0.63)',
+              backgroundColor: item.metadata?.contraband
+                ? 'rgba(255, 105, 97, 0.63)'
+                : isSlotWithItem(item)
+                ? 'rgba(142, 142, 142,0.63)'
+                : 'rgba(71, 71, 71, 0.63)',
               backgroundImage: `url(${item?.name ? getItemUrl(item as SlotWithItem) : 'none'}`,
             }}
             key={`hotbar-${item.slot}`}


### PR DESCRIPTION
## Summary
- show contraband color in hotbar slots when toggling the hotbar

## Testing
- `pre-commit` *(fails: command not found)*
- `npm run format` *(fails: missing dependencies)*