### PR TITLE
Add contraband tooltip indicator

### DIFF
--- a/web/src/components/inventory/SlotTooltip.tsx
+++ b/web/src/components/inventory/SlotTooltip.tsx
@@ -32,6 +32,9 @@ const SlotTooltip: React.ForwardRefRenderFunction<
         </div>
       ) : (
         <div style={{ ...style }} className="tooltip-wrapper" ref={ref}>
+          {item.metadata?.contraband && (
+            <p className="tooltip-contraband">[CONTRABAND]</p>
+          )}
           <div className="tooltip-header-wrapper">
             <p>{item.metadata?.label || itemData.label || item.name}</p>
             {inventoryType === 'crafting' ? (

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -100,6 +100,13 @@ input[type='number']::-webkit-outer-spin-button {
   margin: 0;
 }
 
+.tooltip-contraband {
+  color: #E74C3C;
+  font-weight: bold;
+  text-align: center;
+  margin: 0 0 4px 0;
+}
+
 button:active {
   transform: translateY(3px);
 }


### PR DESCRIPTION
## Summary
- show a red `[CONTRABAND]` tag at the top of item tooltips
- add styles for the contraband tooltip indicator

## Testing
- `node -v`